### PR TITLE
Fix text-transform to display "Ruby" with proper casing

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -180,6 +180,10 @@ input, select, textarea {
 		font-size: 0.9em;
 	}
 
+	.text-transform-none {
+		text-transform: none !important;
+	}
+
 /* Container */
 
 	.container {

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
     <div id="page-wrapper">
       <!-- Header -->
       <header id="header" class="alt">
-        <h1 id="logo"><a href="index.html">北陸Ruby会議01</a></h1>
+        <h1 id="logo" class="text-transform-none"><a href="index.html">北陸Ruby会議01</a></h1>
         <nav id="nav">
           <ul>
             <li><a href="#schedule">SCHEDULE</a></li>
@@ -49,7 +49,7 @@
       <section id="banner">
         <div class="inner">
           <header>
-            <h2>北陸Ruby会議01</h2>
+            <h2 class="text-transform-none">北陸Ruby会議01</h2>
           </header>
           <br />
           <strong>みんなのRubyの使い方</strong><br /><br />


### PR DESCRIPTION
### 概要
`RUBY` を `Ruby` と表示するように修正

### 変更内容
- 見出しの style は `text-transform: uppercase` のまま、個別に css class で uppercase にしないように変更

| 変更後 | 変更前 |
|---|---|
| <img width="3392" height="2066" alt="Screenshot 2025-07-16 at 11-53-32 北陸Ruby会議01" src="https://github.com/user-attachments/assets/a2573634-d6c5-41c1-987a-efe7831f63cd" /> | <img width="3392" height="2066" alt="Screenshot 2025-07-16 at 11-56-29 北陸Ruby会議01" src="https://github.com/user-attachments/assets/c7b01d7b-f55c-46ca-badf-15383e255c59" /> |

### 変更詳細
以下のように uppercase にしたくない要素に`.text-transform-none` を追加すると `text-transform: none` を適用します。
```html
<h2 class="text-transform-none">北陸Ruby会議01</h2>
```