### PR TITLE
TOP: 発表者募集ページリンク追加

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,11 @@
           <footer>
             <ul class="buttons stacked">
               <li>
+                <a class="button primary fit scrolly" href="./cfp.html">
+                  発表者募集中
+                </a>
+              </li>
+              <li>
                 <button class="button fit scrolly">
                   Registration (準備中)
                 </button>


### PR DESCRIPTION
### 概要
TOPヘッダーに発表者募集ページへのリンク追加

### 変更内容
- TOPページ: CFP ページへのリンク追加

| 変更後 | 変更前 |
|---|---|
| <img width="2500" height="1524" alt="Screenshot 2025-09-22 at 11-58-45 北陸Ruby会議01" src="https://github.com/user-attachments/assets/083fcfea-20cf-45b8-a32c-d0f57c8f3c78" /> | <img width="2500" height="1524" alt="Screenshot 2025-09-22 at 11-58-58 北陸Ruby会議01" src="https://github.com/user-attachments/assets/fd882abf-1c57-45c0-a694-9a1f511ceeaa" /> |
