### PR TITLE
Disable link to apply cfp

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2252,6 +2252,15 @@ input, select, textarea {
 			padding: 0.5em 0;
 		}
 
+	input[type="button"],
+	input[type="submit"],
+	input[type="reset"],
+	button.disabled,
+	.button.disabled {
+		pointer-events: none;
+		opacity: 0.5;
+	}
+
 /* Wrapper */
 
 	.wrapper {

--- a/cfp.html
+++ b/cfp.html
@@ -64,6 +64,9 @@
             <h2 class="text-transform-none">北陸Ruby会議01発表者募集</h2>
           </header>
           <p>
+            <strong>北陸Ruby会議01の発表者募集の応募受付は終了しました。<br />たくさんの応募ありがとうございました。</strong><br />
+            <br />
+            <br />
             北陸Ruby会議01でスピーカー希望の方を以下の内容で募集します。<br />
             <br />
             北陸Ruby会議01のテーマは、「みんなの Ruby の使い方」です。 発表者・参加者のいろいろな Ruby の使い方の事例を紹介しあうことで、北陸における Ruby の活用の幅を広げ、Ruby を利活用する人口を増やしたいと考えています。<br />
@@ -118,7 +121,7 @@
                 ・この発表を検討すべき理由と、そのテーマで発表する資格があることの説明 (レビュー委員会向け)
                 <br />
                 <br />
-                <a class="button primary" href="https://forms.gle/1fq6BkvsnMTvePNw5" target="_blank">発表に応募する</a><br />
+                <a class="button primary disabled" href="https://forms.gle/1fq6BkvsnMTvePNw5" target="_blank">発表に応募する</a><br />
                 <br />
                 <small>Google フォームからの送信が難しい場合、メールでの申込みも受け付けています。「Google フォームからの送信が難しい場合」の記載内容を確認の上、申込みをお願いします。</small><br />
                 <br />

--- a/index.html
+++ b/index.html
@@ -70,11 +70,6 @@
           <footer>
             <ul class="buttons stacked">
               <li>
-                <a class="button primary fit scrolly" href="./cfp.html">
-                  発表者募集中
-                </a>
-              </li>
-              <li>
                 <button class="button fit scrolly">
                   Registration (準備中)
                 </button>


### PR DESCRIPTION
### 概要
発表者募集リンクの無効化

### 変更内容
- 発表者募集ページの応募リンクの無効化
- TOPページ: CFP ページへのリンク削除
  - グローバルナビからはまだ削除していません。

### NOTE
- この Pull Request は、発表者募集締切の2025/10/1(Wed) 12:00 (JST)の後にマージします。