### PR TITLE
update registration link

### DIFF
--- a/docs/assets/css/styles.css
+++ b/docs/assets/css/styles.css
@@ -236,15 +236,6 @@ a:hover { color: #555; }
   color: #fff;
 }
 
-.cta-button-skeleton {
-  cursor: not-allowed;
-  pointer-events: none;
-}
-
-.cta-button-skeleton:hover {
-  transform: none;
-}
-
 /* Section Styles */
 .section {
   padding: 5rem 0;

--- a/docs/index.html
+++ b/docs/index.html
@@ -53,7 +53,7 @@
                         <span class="detail-value">石川県立図書館</span>
                     </div>
                 </div>
-                <a href="https://hokurikurb.doorkeeper.jp/events/191562" class="cta-button" target="_blank">参加申込</a>
+                <a href="https://hokurikurb.doorkeeper.jp/events/191562" class="cta-button-skeleton" target="_blank">参加申込</a>
             </div>
         </div>
       </div>


### PR DESCRIPTION
イベントページへのリンクを更新しました。

<img width="1326" height="1316" alt="CleanShot 2025-10-19 at 22 43 25@2x" src="https://github.com/user-attachments/assets/1f5f2d64-8e64-4a2a-8ae8-b817a32d47ef" />

利用する class 名は css の class 一覧を眺めて推測しました。
ただ、ボタンがやや背景に埋もれているような気がしており、これで適切かやや自信がありません。

memo: イベントページはまだ未公開なのでマージはイベントページの公開後に行うこと